### PR TITLE
Removed redundant type property for tracking.js

### DIFF
--- a/src/module-elasticsuite-tracker/view/frontend/layout/default.xml
+++ b/src/module-elasticsuite-tracker/view/frontend/layout/default.xml
@@ -17,7 +17,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <link src="Smile_ElasticsuiteTracker::js/tracking.js" type="text/javascript"/>
+        <link src="Smile_ElasticsuiteTracker::js/tracking.js"/>
     </head>
     <body>
         <referenceContainer name="head.additional">


### PR DESCRIPTION
Very minor issue, Magento automatically adds the type="text/javascript" property to <link/> elements, this results in two type properties on the front-end:

https://i.imgur.com/dD88Dp5.png